### PR TITLE
Add a custom operation timeout parameter

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.10"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ from yourappfolder import sdk
 @sdk.operation(
     methods=["POST", "PATCH"],
     path=["signup", "register", {"name": "date"}, {"name": "test"}],
+    timeout=60000  ## Optional parameter to set a custom timeout for operation in milliseconds
 )
 def signup_register_op(operation, request):
     """

--- a/aidbox_python_sdk/sdk.py
+++ b/aidbox_python_sdk/sdk.py
@@ -233,7 +233,7 @@ class SDK(object):
                 self._operations[operation_id] = {
                     "method": method,
                     "path": path,
-                    "timeout": timeout if timeout else 30000
+                    **({"timeout": timeout} if timeout else {})
                 }
                 self._operation_handlers[operation_id] = wrapped_func
                 if public is True:

--- a/aidbox_python_sdk/sdk.py
+++ b/aidbox_python_sdk/sdk.py
@@ -197,7 +197,7 @@ class SDK(object):
         return self.was_subscription_triggered_n_times(entity, 1)
 
     def operation(
-        self, methods, path, public=False, access_policy=None, request_schema=None
+        self, methods, path, public=False, access_policy=None, request_schema=None, timeout=None
     ):
         if public == True and access_policy is not None:
             raise ValueError(
@@ -233,6 +233,7 @@ class SDK(object):
                 self._operations[operation_id] = {
                     "method": method,
                     "path": path,
+                    "timeout": timeout if timeout else 30000
                 }
                 self._operation_handlers[operation_id] = wrapped_func
                 if public is True:
@@ -273,7 +274,7 @@ class SDK(object):
 
 def validate_request(request_validator, request):
     errors = list(request_validator.iter_errors(request))
-    
+
     if errors:
         raise OperationOutcome(
             resource={

--- a/example/Pipfile
+++ b/example/Pipfile
@@ -42,7 +42,7 @@ Jinja2 = "==3.0.2"
 SQLAlchemy = ">=1.4.26"
 fhirpy = "==1.2.1"
 aidboxpy = "==1.2.0"
-aidbox-python-sdk = {git = "https://github.com/Aidbox/aidbox-python-sdk.git",ref = "103dbdbb6fe3b98cdcdafa39c919d52b6b56cb81"}
+aidbox-python-sdk = {git = "https://github.com/Aidbox/aidbox-python-sdk.git",ref = "07f444f9eeb3056f17d2c715796d5b04e7dfd8f9"}
 fhirpathpy = {git = "https://github.com/beda-software/fhirpath-py.git",ref = "aaac1a4209e3e3cbce6f62246c0822c6cdaf5af5"}
 
 

--- a/example/Pipfile
+++ b/example/Pipfile
@@ -42,7 +42,7 @@ Jinja2 = "==3.0.2"
 SQLAlchemy = ">=1.4.26"
 fhirpy = "==1.2.1"
 aidboxpy = "==1.2.0"
-aidbox-python-sdk = {git = "https://github.com/Aidbox/aidbox-python-sdk.git",ref = "afb53861b6df2566f0ea0c89600de42a1a324d43"}
+aidbox-python-sdk = {git = "https://github.com/Aidbox/aidbox-python-sdk.git",ref = "103dbdbb6fe3b98cdcdafa39c919d52b6b56cb81"}
 fhirpathpy = {git = "https://github.com/beda-software/fhirpath-py.git",ref = "aaac1a4209e3e3cbce6f62246c0822c6cdaf5af5"}
 
 

--- a/example/app/__init__.py
+++ b/example/app/__init__.py
@@ -1,3 +1,4 @@
 
 
 import app.notification
+import app.timeout

--- a/example/app/timeout.py
+++ b/example/app/timeout.py
@@ -1,0 +1,16 @@
+import asyncio
+from aiohttp import web
+
+from app.sdk import sdk
+
+
+@sdk.operation(["GET"], ["$default-timeout"])
+async def operation_handler_with_default_timeout(operation, request):
+    await asyncio.sleep(1)
+    return web.json_response({"result": "success"})
+
+
+@sdk.operation(["GET"], ["$custom-timeout"], timeout=500)
+async def operation_handler_with_custom_timeout(operation, request):
+    await asyncio.sleep(1)
+    return web.json_response({"result": "should_not_be_returned"})

--- a/example/app/timeout.py
+++ b/example/app/timeout.py
@@ -10,7 +10,8 @@ async def operation_handler_with_default_timeout(operation, request):
     return web.json_response({"result": "success"})
 
 
-@sdk.operation(["GET"], ["$custom-timeout"], timeout=500)
+@sdk.operation(["GET"], ["$sleep", {"name": "sleep-ms"}], timeout=2000)
 async def operation_handler_with_custom_timeout(operation, request):
-    await asyncio.sleep(1)
-    return web.json_response({"result": "should_not_be_returned"})
+    sleep_duration = int(request["route-params"]["sleep-ms"])
+    await asyncio.sleep(sleep_duration)
+    return web.json_response({"result": "success"})

--- a/example/tests/test_timeout.py
+++ b/example/tests/test_timeout.py
@@ -10,7 +10,12 @@ async def test_default_timout_works(sdk, safe_db):
     assert response == {"result": "success"}
 
 
-async def test_custom_timout_applied(sdk, safe_db):
+async def test_sleep_operation_fails(sdk, safe_db):
     with pytest.raises(fhirpy.base.exceptions.OperationOutcome) as timeout_exc:
-        response = await sdk.client.execute("$custom-timeout", "GET")
+        await sdk.client.execute("$sleep/2500", "GET")
     assert "idle timeout" in str(timeout_exc)
+
+
+async def test_sleep_operation_succeeds(sdk, safe_db):
+    response = await sdk.client.execute("$sleep/1", "GET")
+    assert response == {"result": "success"}

--- a/example/tests/test_timeout.py
+++ b/example/tests/test_timeout.py
@@ -1,0 +1,16 @@
+import logging
+import asyncio
+import pytest
+
+import fhirpy
+
+
+async def test_default_timout_works(sdk, safe_db):
+    response = await sdk.client.execute("$default-timeout", "GET")
+    assert response == {"result": "success"}
+
+
+async def test_custom_timout_applied(sdk, safe_db):
+    with pytest.raises(fhirpy.base.exceptions.OperationOutcome) as timeout_exc:
+        response = await sdk.client.execute("$custom-timeout", "GET")
+    assert "idle timeout" in str(timeout_exc)


### PR DESCRIPTION
There are three updates:
- Feature update
- Documentation update
- Add an example with tests

Usage:
@sdk.operation(
    methods=["POST", "PATCH"],
    path=["signup", "register", {"name": "date"}, {"name": "test"}],
    timeout=60000  ## Optional parameter to set a custom timeout for operation in milliseconds
)
def signup_register_op(operation, request): 
   ...
