### PR TITLE
SDK refactoring

### DIFF
--- a/.env-tpl
+++ b/.env-tpl
@@ -1,5 +1,5 @@
-AIDBOX_LICENSE_ID=
-AIDBOX_LICENSE_KEY=
+# Visit https://aidbox.app/ui/portal to get a licence key
+AIDBOX_LICENSE=
 
 # comment to get unsecured box
 AIDBOX_CLIENT_ID=root
@@ -16,6 +16,7 @@ APP_INIT_URL=http://devbox:8080
 APP_ID=app-py-example
 APP_SECRET=secret
 APP_URL=http://app:8081
+APP_PORT=8081
 AIO_PORT=8081
 AIO_HOST=0.0.0.0
 AIO_APP_PATH=.

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 venv
 .DS_Store
 aidbox_python_sdk.egg-info/
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv
 .DS_Store
 aidbox_python_sdk.egg-info/
 .python-version
+.vscode

--- a/aidbox_python_sdk/aidboxpy.py
+++ b/aidbox_python_sdk/aidboxpy.py
@@ -1,0 +1,139 @@
+from abc import ABC
+
+from fhirpy.base import (
+    SyncClient,
+    AsyncClient,
+    SyncSearchSet,
+    AsyncSearchSet,
+    SyncResource,
+    AsyncResource,
+    SyncReference,
+    AsyncReference,
+)
+from fhirpy.base.resource import BaseResource, BaseReference
+from fhirpy.base.searchset import AbstractSearchSet
+
+__title__ = "aidbox-py"
+__version__ = "1.3.0"
+__author__ = "beda.software"
+__license__ = "None"
+__copyright__ = "Copyright 2021 beda.software"
+
+# Version synonym
+VERSION = __version__
+
+
+class AidboxSearchSet(AbstractSearchSet, ABC):
+    def assoc(self, element_path):
+        return self.clone(**{"_assoc": element_path})
+
+
+class SyncAidboxSearchSet(SyncSearchSet, AidboxSearchSet):
+    pass
+
+
+class AsyncAidboxSearchSet(AsyncSearchSet, AidboxSearchSet):
+    pass
+
+
+class BaseAidboxResource(BaseResource, ABC):
+    def is_reference(self, value):
+        if not isinstance(value, dict):
+            return False
+
+        return (
+            "resourceType" in value
+            and ("id" in value or "url" in value)
+            and not (
+                set(value.keys())
+                - {
+                    "resourceType",
+                    "id",
+                    "_id",
+                    "resource",
+                    "display",
+                    "uri",
+                    "localRef",
+                    "identifier",
+                    "extension",
+                }
+            )
+        )
+
+
+class SyncAidboxResource(BaseAidboxResource, SyncResource):
+    pass
+
+
+class AsyncAidboxResource(BaseAidboxResource, AsyncResource):
+    pass
+
+
+class BaseAidboxReference(BaseReference, ABC):
+    @property
+    def reference(self):
+        """
+        Returns reference if local resource is saved
+        """
+        if self.is_local:
+            return "{0}/{1}".format(self.resource_type, self.id)
+        return self.get("url", None)
+
+    @property
+    def id(self):
+        if self.is_local:
+            return self.get("id", None)
+
+    @property
+    def resource_type(self):
+        """
+        Returns resource type if reference specifies to the local resource
+        """
+        if self.is_local:
+            return self.get("resourceType", None)
+
+    @property
+    def is_local(self):
+        return not self.get("url")
+
+
+class SyncAidboxReference(BaseAidboxReference, SyncReference):
+    pass
+
+
+class AsyncAidboxReference(BaseAidboxReference, AsyncReference):
+    pass
+
+
+class SyncAidboxClient(SyncClient):
+    searchset_class = SyncAidboxSearchSet
+    resource_class = SyncAidboxResource
+
+    def reference(self, resource_type=None, id=None, reference=None, **kwargs):
+        resource_type = kwargs.pop("resourceType", resource_type)
+        if reference:
+            if reference.count("/") > 1:
+                return SyncAidboxReference(self, url=reference, **kwargs)
+            resource_type, id = reference.split("/")
+        if not resource_type and not id:
+            raise TypeError(
+                "Arguments `resource_type` and `id` or `reference`" "are required"
+            )
+        return SyncAidboxReference(self, resourceType=resource_type, id=id, **kwargs)
+
+
+class AsyncAidboxClient(AsyncClient):
+    searchset_class = AsyncAidboxSearchSet
+    resource_class = AsyncAidboxResource
+
+    def reference(self, resource_type=None, id=None, reference=None, **kwargs):
+        resource_type = kwargs.pop("resourceType", resource_type)
+        if reference:
+            if reference.count("/") > 1:
+                return AsyncAidboxReference(self, url=reference, **kwargs)
+            resource_type, id = reference.split("/")
+        if not resource_type and not id:
+            raise TypeError(
+                "Arguments `resource_type` and `id` or `reference`" "are required"
+            )
+        return AsyncAidboxReference(self, resourceType=resource_type, id=id, **kwargs)

--- a/aidbox_python_sdk/db.py
+++ b/aidbox_python_sdk/db.py
@@ -86,6 +86,7 @@ class DBProxy(object):
             password=self._settings.APP_INIT_CLIENT_SECRET,
         )
         self._client = ClientSession(auth=basic_auth)
+        # TODO: remove _init_table_cache
         await self._init_table_cache()
 
     async def deinitialize(self):

--- a/aidbox_python_sdk/handlers.py
+++ b/aidbox_python_sdk/handlers.py
@@ -19,7 +19,7 @@ async def subscription(request, data):
     if not handler:
         logger.error("Subscription handler `{}` was not found".format(data["handler"]))
         raise web.HTTPNotFound()
-    result = handler(data["event"])
+    result = handler(data["event"], request)
     if asyncio.iscoroutine(result):
         asyncio.get_event_loop().create_task(result)
     return web.json_response({})

--- a/aidbox_python_sdk/handlers.py
+++ b/aidbox_python_sdk/handlers.py
@@ -54,7 +54,7 @@ TYPES = {
 }
 
 
-@routes.post("/")
+@routes.post("/aidbox")
 async def dispatch(request):
     logger.debug("Dispatch new request {} {}".format(request.method, request.url))
     json = await request.json()
@@ -72,7 +72,7 @@ async def dispatch(request):
     return web.json_response(req, status=200)
 
 
-@routes.get("/")
+@routes.get("/health")
 async def health_check(request):
     return web.json_response({"status": "OK"}, status=200)
 

--- a/aidbox_python_sdk/handlers.py
+++ b/aidbox_python_sdk/handlers.py
@@ -10,8 +10,6 @@ routes = web.RouteTableDef()
 
 async def subscription(request, data):
     logger.debug("Subscription handler: {}".format(data["handler"]))
-    if not request.app["sdk"].is_initialized():
-        raise web.HTTPServiceUnavailable()
     if "handler" not in data or "event" not in data:
         logger.error("`handler` and/or `event` param is missing, data: {}".format(data))
         raise web.HTTPBadRequest()
@@ -27,8 +25,6 @@ async def subscription(request, data):
 
 async def operation(request, data):
     logger.debug("Operation handler: %s", data["operation"]["id"])
-    if not request.app["sdk"].is_initialized():
-        raise web.HTTPServiceUnavailable()
     if "operation" not in data or "id" not in data["operation"]:
         logger.error(
             "`operation` or `operation[id]` param is missing, data: %s", data
@@ -83,6 +79,4 @@ async def health_check(request):
 
 @routes.get("/live")
 async def live_health_check(request):
-    if not request.app["sdk"].is_initialized():
-        raise web.HTTPServiceUnavailable()
     return web.json_response({"status": "OK"}, status=200)

--- a/aidbox_python_sdk/main.py
+++ b/aidbox_python_sdk/main.py
@@ -56,7 +56,7 @@ async def init_aidbox(app):
         sys.exit(errno.EINTR)
 
 
-async def wait_and_init_aidbox(app):
+async def wait_aidbox(app):
     address = app["settings"].APP_URL
     logger.debug("Check availability of {}".format(address))
     while 1:
@@ -70,6 +70,10 @@ async def wait_and_init_aidbox(app):
             client_exceptions.ClientConnectionError,
         ):
             await asyncio.sleep(2)
+
+
+async def wait_and_init_aidbox(app):
+    await wait_aidbox(app)
     await init_aidbox(app)
 
 

--- a/aidbox_python_sdk/main.py
+++ b/aidbox_python_sdk/main.py
@@ -31,7 +31,7 @@ async def register_app(sdk: SDK, client: AsyncAidboxClient):
             "type": "app",
             "id": sdk.settings.APP_ID,
             "endpoint": {
-                "url": sdk.settings.APP_URL,
+                "url": f"{sdk.settings.APP_URL}/aidbox",
                 "type": "http-rpc",
                 "secret": sdk.settings.APP_SECRET,
             },

--- a/aidbox_python_sdk/main.py
+++ b/aidbox_python_sdk/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import errno
+import json
 import logging
 import os
 import sys
@@ -11,6 +12,7 @@ from .aidboxpy import AsyncAidboxClient
 from .db import DBProxy
 from .handlers import routes
 from .sdk import SDK
+from fhirpy.base.exceptions import OperationOutcome
 
 logger = logging.getLogger("aidbox_sdk")
 THIS_DIR = Path(__file__).parent
@@ -21,36 +23,33 @@ def setup_routes(app):
     app.add_routes(routes)
 
 
-async def register_app(
-    sdk: SDK, *, http_client: ClientSession, aidbox_client: AsyncAidboxClient
-):
-    try:
-        async with http_client.put(
-            "{}/App".format(sdk.settings.APP_INIT_URL),
-            json={
-                "resourceType": "App",
-                "apiVersion": 1,
-                "type": "app",
-                "id": sdk.settings.APP_ID,
-                "endpoint": {
-                    "url": sdk.settings.APP_URL,
-                    "type": "http-rpc",
-                    "secret": sdk.settings.APP_SECRET,
-                },
-                **sdk.build_manifest(),
+async def register_app(sdk: SDK, client: AsyncAidboxClient):
+    app_resource = client.resource(
+        "App",
+        **{
+            "apiVersion": 1,
+            "type": "app",
+            "id": sdk.settings.APP_ID,
+            "endpoint": {
+                "url": sdk.settings.APP_URL,
+                "type": "http-rpc",
+                "secret": sdk.settings.APP_SECRET,
             },
-        ) as resp:
-            if 200 <= resp.status < 300:
-                logger.info("Initializing Aidbox app...")
-                await sdk.initialize(aidbox_client)
-            else:
-                logger.error(
-                    "Aidbox app initialized failed. "
-                    "Response from Aidbox: {0} {1}".format(
-                        resp.status, await resp.text()
-                    )
+            **sdk.build_manifest(),
+        }
+    )
+    try:
+        try:
+            await app_resource.save()
+            logger.info("Creating seeds and applying migrations")
+            await sdk.initialize(client)
+        except OperationOutcome as error:
+            logger.error(
+                "Error during the App registration: {}".format(
+                    json.dumps(error, indent=2)
                 )
-                sys.exit(errno.EINTR)
+            )
+            sys.exit(errno.EINTR)
     except (
         client_exceptions.ServerDisconnectedError,
         client_exceptions.ClientConnectionError,
@@ -61,15 +60,7 @@ async def register_app(
         sys.exit(errno.EINTR)
 
 
-async def init_http_client(app):
-    basic_auth = BasicAuth(
-        login=app["settings"].APP_INIT_CLIENT_ID,
-        password=app["settings"].APP_INIT_CLIENT_SECRET,
-    )
-    app["init_http_client"] = ClientSession(auth=basic_auth)
-
-
-async def init_aidbox_client(app):
+async def init_client(app):
     basic_auth = BasicAuth(
         login=app["settings"].APP_INIT_CLIENT_ID,
         password=app["settings"].APP_INIT_CLIENT_SECRET,
@@ -87,24 +78,15 @@ async def init_db(app):
 
 
 async def on_startup(app):
-    await init_http_client(app)
-    await init_aidbox_client(app)
+    await init_client(app)
     await init_db(app)
 
-    await register_app(
-        app["sdk"], http_client=app["init_http_client"], aidbox_client=app["client"]
-    )
+    await register_app(app["sdk"], app["client"])
 
 
 async def on_cleanup(app):
-    await app["init_http_client"].close()
     await app["db"].deinitialize()
     await app["sdk"].deinitialize()
-
-
-async def on_shutdown(app):
-    if not app["init_http_client"].closed:
-        await app["init_http_client"].close()
 
 
 def create_app(sdk: SDK):
@@ -112,7 +94,6 @@ def create_app(sdk: SDK):
     app = web.Application()
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)
-    app.on_shutdown.append(on_shutdown)
     app.update(
         name="aidbox-python-sdk",
         settings=sdk.settings,

--- a/aidbox_python_sdk/main.py
+++ b/aidbox_python_sdk/main.py
@@ -42,7 +42,8 @@ async def register_app(sdk: SDK, client: AsyncAidboxClient):
     try:
         await app_resource.save()
         logger.info("Creating seeds and applying migrations")
-        await sdk.handle_seeds_and_migrations(client)
+        await sdk.create_seed_resources(client)
+        await sdk.apply_migrations(client)
         logger.info("Aidbox app successfully registered")
     except OperationOutcome as error:
         logger.error(

--- a/aidbox_python_sdk/main.py
+++ b/aidbox_python_sdk/main.py
@@ -38,7 +38,7 @@ async def init_aidbox(app):
         ) as resp:
             if 200 <= resp.status < 300:
                 logger.info("Initializing Aidbox app...")
-                await app["sdk"].initialize(app["aidbox_client"])
+                await app["sdk"].initialize(app["client"])
             else:
                 logger.error(
                     "Aidbox app initialized failed. "
@@ -91,7 +91,7 @@ async def init_aidbox_client(app):
         login=app["settings"].APP_INIT_CLIENT_ID,
         password=app["settings"].APP_INIT_CLIENT_SECRET,
     )
-    app["aidbox_client"] = AsyncAidboxClient(
+    app["client"] = AsyncAidboxClient(
         "{}".format(app["settings"].APP_INIT_URL), authorization=basic_auth.encode()
     )
 

--- a/aidbox_python_sdk/main.py
+++ b/aidbox_python_sdk/main.py
@@ -95,7 +95,6 @@ def create_app(sdk: SDK):
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)
     app.update(
-        name="aidbox-python-sdk",
         settings=sdk.settings,
         sdk=sdk,
     )

--- a/aidbox_python_sdk/main.py
+++ b/aidbox_python_sdk/main.py
@@ -42,7 +42,8 @@ async def register_app(sdk: SDK, client: AsyncAidboxClient):
         try:
             await app_resource.save()
             logger.info("Creating seeds and applying migrations")
-            await sdk.initialize(client)
+            await sdk.handle_seeds_and_migrations(client)
+            logger.info("Aidbox app successfully registered")
         except OperationOutcome as error:
             logger.error(
                 "Error during the App registration: {}".format(
@@ -86,11 +87,9 @@ async def on_startup(app):
 
 async def on_cleanup(app):
     await app["db"].deinitialize()
-    await app["sdk"].deinitialize()
 
 
 def create_app(sdk: SDK):
-    sdk.is_ready = asyncio.Future()
     app = web.Application()
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)

--- a/aidbox_python_sdk/pytest_plugin.py
+++ b/aidbox_python_sdk/pytest_plugin.py
@@ -81,3 +81,8 @@ async def safe_db(aidbox, client):
 @pytest.fixture
 def sdk(client):
     return client.server.app["sdk"]
+
+
+@pytest.fixture
+def aidbox_client(client):
+    return client.server.app["aidbox_client"]

--- a/aidbox_python_sdk/pytest_plugin.py
+++ b/aidbox_python_sdk/pytest_plugin.py
@@ -18,7 +18,6 @@ async def start_app(aiohttp_client):
     sdk = app.server.app["sdk"]
     sdk._test_start_txid = -1
 
-    await sdk.is_ready
     return app
 
 

--- a/aidbox_python_sdk/pytest_plugin.py
+++ b/aidbox_python_sdk/pytest_plugin.py
@@ -13,7 +13,7 @@ from main import create_app as _create_app
 
 async def start_app(aiohttp_client):
     app = await aiohttp_client(
-        await _create_app(), server_kwargs={"host": "0.0.0.0", "port": 8081}
+        _create_app(), server_kwargs={"host": "0.0.0.0", "port": 8081}
     )
     sdk = app.server.app["sdk"]
     sdk._test_start_txid = -1

--- a/aidbox_python_sdk/pytest_plugin.py
+++ b/aidbox_python_sdk/pytest_plugin.py
@@ -12,7 +12,6 @@ from main import create_app as _create_app
 
 
 async def start_app(aiohttp_client):
-
     app = await aiohttp_client(
         await _create_app(), server_kwargs={"host": "0.0.0.0", "port": 8081}
     )
@@ -77,6 +76,7 @@ async def safe_db(aidbox, client):
         params={"execute": "true"},
         raise_for_status=True,
     )
+
 
 @pytest.fixture
 def sdk(client):

--- a/aidbox_python_sdk/pytest_plugin.py
+++ b/aidbox_python_sdk/pytest_plugin.py
@@ -85,4 +85,4 @@ def sdk(client):
 
 @pytest.fixture
 def aidbox_client(client):
-    return client.server.app["aidbox_client"]
+    return client.server.app["client"]

--- a/aidbox_python_sdk/pytest_plugin.py
+++ b/aidbox_python_sdk/pytest_plugin.py
@@ -23,9 +23,9 @@ async def start_app(aiohttp_client):
 
 
 @pytest.fixture
-def client(loop, aiohttp_client):
+def client(event_loop, aiohttp_client):
     """Instance of app's server and client"""
-    return loop.run_until_complete(start_app(aiohttp_client))
+    return event_loop.run_until_complete(start_app(aiohttp_client))
 
 
 class AidboxSession(ClientSession):

--- a/aidbox_python_sdk/sdk.py
+++ b/aidbox_python_sdk/sdk.py
@@ -4,10 +4,8 @@ import os
 
 import jsonschema
 from aidboxpy import AsyncAidboxClient
-from aiohttp import BasicAuth, ClientSession
-from fhirpy.base.exceptions import OperationOutcome, ResourceNotFound
+from fhirpy.base.exceptions import OperationOutcome
 
-from .db import DBProxy
 from .db_migrations import sdk_migrations
 
 logger = logging.getLogger("aidbox_sdk")
@@ -51,13 +49,11 @@ class SDK(object):
         self._initialized = False
         self._sub_triggered = {}
         self.is_ready = asyncio.Future()
-        self.db = DBProxy(self._settings)
         self._test_start_txid = None
 
     async def initialize(self, client: AsyncAidboxClient):
         await self._create_seed_resources(client)
         await self._apply_migrations(client)
-        await self.db.initialize()
 
         self._initialized = True
         logger.info("Aidbox app successfully initialized")
@@ -71,7 +67,6 @@ class SDK(object):
         if not self.is_initialized():
             return
 
-        await self.db.deinitialize()
         self._initialized = False
 
         if callable(self._on_deinitialize):

--- a/aidbox_python_sdk/sdk.py
+++ b/aidbox_python_sdk/sdk.py
@@ -45,11 +45,7 @@ class SDK(object):
         self._sub_triggered = {}
         self._test_start_txid = None
 
-    async def handle_seeds_and_migrations(self, client: AsyncAidboxClient):
-        await self._create_seed_resources(client)
-        await self._apply_migrations(client)
-
-    async def _apply_migrations(self, client: AsyncAidboxClient):
+    async def apply_migrations(self, client: AsyncAidboxClient):
         await client.resource(
             "Bundle",
             type="transaction",
@@ -61,7 +57,7 @@ class SDK(object):
             ],
         ).save()
 
-    async def _create_seed_resources(self, client: AsyncAidboxClient):
+    async def create_seed_resources(self, client: AsyncAidboxClient):
         entries = []
         for entity, resources in self._seeds.items():
             for resource_id, resource in resources.items():

--- a/aidbox_python_sdk/sdk.py
+++ b/aidbox_python_sdk/sdk.py
@@ -3,9 +3,9 @@ import logging
 import os
 
 import jsonschema
-from aidboxpy import AsyncAidboxClient
 from fhirpy.base.exceptions import OperationOutcome
 
+from .aidboxpy import AsyncAidboxClient
 from .db_migrations import sdk_migrations
 
 logger = logging.getLogger("aidbox_sdk")
@@ -20,10 +20,8 @@ class SDK(object):
         resources=None,
         seeds=None,
         migrations=None,
-        on_ready=None,
-        on_deinitialize=None
     ):
-        self._settings = settings
+        self.settings = settings
         self._subscriptions = {}
         self._subscription_handlers = {}
         self._operations = {}
@@ -43,12 +41,10 @@ class SDK(object):
         self._entities = entities or {}
         self._seeds = seeds or {}
         self._migrations = migrations or []
-        self._on_ready = on_ready
-        self._on_deinitialize = on_deinitialize
         self._app_endpoint_name = "{}-endpoint".format(settings.APP_ID)
         self._initialized = False
         self._sub_triggered = {}
-        self.is_ready = asyncio.Future()
+        self.is_ready = None
         self._test_start_txid = None
 
     async def initialize(self, client: AsyncAidboxClient):
@@ -58,9 +54,6 @@ class SDK(object):
         self._initialized = True
         logger.info("Aidbox app successfully initialized")
 
-        if callable(self._on_ready):
-            await self._on_ready()
-
         self.is_ready.set_result(True)
 
     async def deinitialize(self):
@@ -68,9 +61,6 @@ class SDK(object):
             return
 
         self._initialized = False
-
-        if callable(self._on_deinitialize):
-            await self._on_deinitialize()
 
     def is_initialized(self):
         return self._initialized

--- a/aidbox_python_sdk/sdk.py
+++ b/aidbox_python_sdk/sdk.py
@@ -126,7 +126,7 @@ class SDK(object):
             path = func.__name__
             self._subscriptions[entity] = {"handler": path}
 
-            async def handler(event):
+            async def handler(event, request):
                 if self._test_start_txid is not None:
                     # Skip outside test
                     if self._test_start_txid == -1:
@@ -135,7 +135,7 @@ class SDK(object):
                     # Skip inside another test
                     if int(event["tx"]["id"]) < self._test_start_txid:
                         return
-                coro_or_result = func(event)
+                coro_or_result = func(event, request)
                 if asyncio.iscoroutine(coro_or_result):
                     result = await coro_or_result
                 else:

--- a/example/app/sdk.py
+++ b/example/app/sdk.py
@@ -20,4 +20,4 @@ sdk = SDK(
     ["GET"], ["healthcheck"], public=True,
 )
 async def healthcheck(operation, request):
-    return web.json_response({"is_ready": sdk.is_ready.result()})
+    return web.json_response({"is_ready": True})

--- a/example/tests/test_base.py
+++ b/example/tests/test_base.py
@@ -7,7 +7,7 @@
 
 
 async def test_health_check(client):
-    resp = await client.get("/")
+    resp = await client.get("/health")
     assert resp.status == 200
     json = await resp.json()
     assert json == {"status": "OK"}

--- a/main.py
+++ b/main.py
@@ -125,7 +125,7 @@ async def daily_patient_report(operation, request):
     GET /Patient/$weekly-report
     GET /Patient/$daily-report
     """
-    patients = sdk.client.resources("Patient")
+    patients = request["app"]["client"].resources("Patient")
     async for p in patients:
         logging.debug(p.serialize())
     logging.debug("`daily_patient_report` operation handler")
@@ -138,7 +138,7 @@ async def daily_patient_report(operation, request):
 
 @routes.get("/db_tests")
 async def db_tests(request):
-    db = sdk.db
+    db = request["app"]["db"]
     app = db.App.__table__
     app_res = {
         "type": "app",

--- a/main.py
+++ b/main.py
@@ -66,22 +66,22 @@ async def create_app():
 
 
 @sdk.subscription("Appointment")
-async def appointment_sub(event):
+async def appointment_sub(event, request):
     """
     POST /Appointment
     """
     await asyncio.sleep(5)
-    return await _appointment_sub(event)
+    return await _appointment_sub(event, request)
 
 
-async def _appointment_sub(event):
+async def _appointment_sub(event, request):
     participants = event["resource"]["participant"]
     patient_id = next(
         p["actor"]["id"]
         for p in participants
         if p["actor"]["resourceType"] == "Patient"
     )
-    patient = await sdk.client.resources("Patient").get(id=patient_id)
+    patient = await request.app["client"].resources("Patient").get(id=patient_id)
     patient_name = "{} {}".format(
         patient["name"][0]["given"][0], patient["name"][0]["family"]
     )
@@ -125,7 +125,7 @@ async def daily_patient_report(operation, request):
     GET /Patient/$weekly-report
     GET /Patient/$daily-report
     """
-    patients = request["app"]["client"].resources("Patient")
+    patients = request.app["client"].resources("Patient")
     async for p in patients:
         logging.debug(p.serialize())
     logging.debug("`daily_patient_report` operation handler")
@@ -138,7 +138,7 @@ async def daily_patient_report(operation, request):
 
 @routes.get("/db_tests")
 async def db_tests(request):
-    db = request["app"]["db"]
+    db = request.app["db"]
     app = db.App.__table__
     app_res = {
         "type": "app",

--- a/main.py
+++ b/main.py
@@ -61,8 +61,8 @@ seeds = {
 sdk = SDK(settings, resources=resources, seeds=seeds)
 
 
-async def create_app():
-    return await _create_app(settings, sdk, debug=True)
+def create_app():
+    return _create_app(sdk)
 
 
 @sdk.subscription("Appointment")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,4 @@ testpaths = [
 ]
 log_cli = true
 log_cli_level = "INFO"
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra -q --color=yes"
+testpaths = [
+    "tests",
+]
+log_cli = true
+log_cli_level = "INFO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,3 @@ testpaths = [
 ]
 log_cli = true
 log_cli_level = "INFO"
-asyncio_mode = "auto"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,5 @@
 aiohttp==3.8.3
 SQLAlchemy==1.4.44
 fhirpy==1.3.0
-aidboxpy==1.3.0
 coloredlogs
 jsonschema>=4.4.0

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -64,6 +64,7 @@ async def test_appointment_sub(client, aidbox):
         }
         assert expected["resource"].items() <= event["resource"].items()
 
+
 @pytest.mark.asyncio
 async def test_database_isolation__1(aidbox_client, safe_db):
     patients = await aidbox_client.resources("Patient").fetch_all()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -65,27 +65,27 @@ async def test_appointment_sub(client, aidbox):
         assert expected["resource"].items() <= event["resource"].items()
 
 @pytest.mark.asyncio
-async def test_database_isolation__1(sdk, safe_db):
-    patients = await sdk.client.resources("Patient").fetch_all()
+async def test_database_isolation__1(aidbox_client, safe_db):
+    patients = await aidbox_client.resources("Patient").fetch_all()
     assert len(patients) == 2
 
-    patient = sdk.client.resource("Patient")
+    patient = aidbox_client.resource("Patient")
     await patient.save()
 
-    patients = await sdk.client.resources("Patient").fetch_all()
+    patients = await aidbox_client.resources("Patient").fetch_all()
     assert len(patients) == 3
 
 
 @pytest.mark.asyncio
-async def test_database_isolation__2(sdk, safe_db):
-    patients = await sdk.client.resources("Patient").fetch_all()
+async def test_database_isolation__2(aidbox_client, safe_db):
+    patients = await aidbox_client.resources("Patient").fetch_all()
     assert len(patients) == 2
 
-    patient = sdk.client.resource("Patient")
+    patient = aidbox_client.resource("Patient")
     await patient.save()
 
-    patient = sdk.client.resource("Patient")
+    patient = aidbox_client.resource("Patient")
     await patient.save()
 
-    patients = await sdk.client.resources("Patient").fetch_all()
+    patients = await aidbox_client.resources("Patient").fetch_all()
     assert len(patients) == 4

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -9,7 +9,7 @@ import main
 
 @pytest.mark.asyncio
 async def test_health_check(client):
-    resp = await client.get("/")
+    resp = await client.get("/health")
     assert resp.status == 200
     json = await resp.json()
     assert json == {"status": "OK"}


### PR DESCRIPTION
**basic changes:**

- [BREAKING CHANGES] move Aidbox client initialisation outside the `SDK` class and store it into `aiohttp.web.Application`

there is no longer such a possibility to use `sdk.client.<AidboxClient methods>`.  For instance, in operations get client via `request.app["client"]`

- [BREAKING CHANGES] store `DBProxy` object into `aiohttp.web.Application` and remove it from `SDK` class

there is no longer such a possibility to use `sdk.db`.  For instance, in operations get `db` object via `request.app["db"]`

- [BREAKING CHANGES] add `request` as a positional argument to subscription handlers

```python
@sdk.subscription("Appointment")
async def appointment_sub(event, request):
    pass
```
