### PR TITLE
Add app object to request and support for custom AidboxClient class

### DIFF
--- a/aidbox_python_sdk/handlers.py
+++ b/aidbox_python_sdk/handlers.py
@@ -35,6 +35,7 @@ async def operation(request, data):
         logger.error("Operation handler `%s` was not found", data["handler"])
         raise web.HTTPNotFound()
     try:
+        data["request"]["app"] = request.app
         result = handler(data["operation"], data["request"])
         if asyncio.iscoroutine(result):
             try:

--- a/aidbox_python_sdk/main.py
+++ b/aidbox_python_sdk/main.py
@@ -51,12 +51,13 @@ async def register_app(sdk: SDK, client: AsyncAidboxClient):
 
 
 async def init_client(settings: Settings):
+    AidboxClient = settings.AIDBOX_CLIENT_CLASS
     basic_auth = BasicAuth(
         login=settings.APP_INIT_CLIENT_ID,
         password=settings.APP_INIT_CLIENT_SECRET,
     )
 
-    return AsyncAidboxClient(
+    return AidboxClient(
         "{}".format(settings.APP_INIT_URL), authorization=basic_auth.encode()
     )
 

--- a/aidbox_python_sdk/settings.py
+++ b/aidbox_python_sdk/settings.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+from .aidboxpy import AsyncAidboxClient
+
 
 class Required:
     def __init__(self, v_type=None):
@@ -30,6 +32,7 @@ class Settings:
     APP_SECRET = Required(v_type=str)
     AIO_HOST = Required(v_type=str)
     AIO_PORT = Required(v_type=str)
+    AIDBOX_CLIENT_CLASS = AsyncAidboxClient
 
     def __init__(self, **custom_settings):
         """


### PR DESCRIPTION
Improvements:
- Add app object to request
  ```python
  # Access Aidbox client from custom operation handler

  @sdk.operation(["POST"], ["example"])
  async def some_op(operation, request):

      client = request["app"]["client"]

      return web.json_response({"status": "OK"})
  ```

- Add support for custom AidboxClient class
  ```python
  # Usage example

  class CustomAsyncAidboxClient(AsyncAidboxClient):
      pass
  
  sdk_settings = Settings(
      **{
          "APP_ID": Config.app_id,
          "APP_URL": Config.app_url,
          "APP_SECRET": Config.app_secret,
          "AIDBOX_CLIENT_CLASS": CustomAsyncAidboxClient
      }
  )
  ```